### PR TITLE
Implement NEM analysis endpoints

### DIFF
--- a/solar-analyzer-worker/db/schema.sql
+++ b/solar-analyzer-worker/db/schema.sql
@@ -21,6 +21,13 @@ CREATE TABLE IF NOT EXISTS pvwatts (
   dhi REAL
 );
 
+CREATE TABLE IF NOT EXISTS pvwatts_hourly (
+  date TEXT,
+  hour TEXT,
+  ac_wh REAL,
+  PRIMARY KEY(date, hour)
+);
+
 CREATE TABLE IF NOT EXISTS sunrise_sunset (
   date TEXT PRIMARY KEY,
   sunrise TEXT,

--- a/solar-analyzer-worker/public/index.html
+++ b/solar-analyzer-worker/public/index.html
@@ -1,32 +1,47 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hello, World!</title>
-	</head>
-	<body>
-		<h1 id="heading"></h1>
-		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
-		<button id="button" type="button">Fetch a random UUID</button>
-		<output id="random" for="button"></output>
-		<script>
-			fetch('/message')
-				.then((resp) => resp.text())
-				.then((text) => {
-					const h1 = document.getElementById('heading');
-					h1.textContent = text;
-				});
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NEM 2.0 Report</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <h1>NEM 2.0 Asset Valuation</h1>
+  <label>Start <input id="start" type="date"></label>
+  <label>End <input id="end" type="date"></label>
+  <button id="run">Run Analysis</button>
+  <button id="pdf">Download PDF</button>
+  <div>
+    <canvas id="chart" width="600" height="300"></canvas>
+  </div>
+  <pre id="summary"></pre>
+<script>
+async function run() {
+  const start = document.getElementById('start').value;
+  const end = document.getElementById('end').value;
+  const resp = await fetch(`/analysis/nem2vnem3?start=${start}&end=${end}`);
+  const data = await resp.json();
+  document.getElementById('summary').textContent = `NEM2: $${data.costNEM2.toFixed(2)}\nNEM3: $${data.costNEM3.toFixed(2)}\nDiff: $${data.diff.toFixed(2)}`;
+  const labels = data.hours.map(h=>`${h.date} ${h.hour}`);
+  const diff = data.hours.map(h=>{const rate=h.hour>=16&&h.hour<21?0.35:0.25; return (h.usage-h.pv)*rate*0.75 - (h.usage-h.pv)*rate});
+  if(window.myChart) window.myChart.destroy();
+  window.myChart = new Chart(document.getElementById('chart'), {
+    type:'bar',
+    data:{labels, datasets:[{label:'NEM3 - NEM2 ($)', data: diff}]}
+  });
+}
 
-			const button = document.getElementById("button");
-			button.addEventListener("click", () => {
-				fetch('/random')
-					.then((resp) => resp.text())
-					.then((text) => {
-						const random = document.getElementById('random');
-						random.textContent = text;
-					});
-			});
-		</script>
-	</body>
+async function downloadPdf() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  doc.text(document.getElementById('summary').textContent, 10, 10);
+  doc.save('report.pdf');
+}
+
+document.getElementById('run').addEventListener('click', run);
+document.getElementById('pdf').addEventListener('click', downloadPdf);
+</script>
+</body>
 </html>

--- a/solar-analyzer-worker/src/index.ts
+++ b/solar-analyzer-worker/src/index.ts
@@ -2,6 +2,7 @@ import { handleUploadPgeUsage } from './services/usageUpload';
 import { handleUploadSolarTest } from './services/solarTestUpload';
 import { handleBackfillPvwatts } from './services/pvwattsBackfill';
 import { handleBackfillSunrise } from './services/sunriseBackfill';
+import { handleNemAnalysis } from './services/nemAnalysis';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -17,6 +18,9 @@ export default {
     }
     if (request.method === 'POST' && url.pathname.startsWith('/backfill/sunrise_sunset')) {
       return handleBackfillSunrise(request, env);
+    }
+    if (request.method === 'GET' && url.pathname.startsWith('/analysis/nem2vnem3')) {
+      return handleNemAnalysis(request, env);
     }
     return new Response('Not Found', { status: 404 });
   }

--- a/solar-analyzer-worker/src/services/clickUp.ts
+++ b/solar-analyzer-worker/src/services/clickUp.ts
@@ -1,0 +1,19 @@
+export class ClickUpService {
+  token: string;
+  constructor(token: string) {
+    this.token = token;
+  }
+  async updateTaskStatus(taskId: string, status: string): Promise<void> {
+    const resp = await fetch(`https://api.clickup.com/api/v2/task/${taskId}`, {
+      method: 'PUT',
+      headers: {
+        'Authorization': this.token,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ status })
+    });
+    if (!resp.ok) {
+      console.warn('ClickUp update failed', await resp.text());
+    }
+  }
+}

--- a/solar-analyzer-worker/src/services/nemAnalysis.ts
+++ b/solar-analyzer-worker/src/services/nemAnalysis.ts
@@ -1,0 +1,66 @@
+import { queryDB } from '../db/client';
+
+interface HourRecord {
+  date: string;
+  hour: string;
+  usage: number;
+  pv: number;
+}
+
+const OFF_PEAK = 0.25;
+const PEAK = 0.35;
+
+function rateForHour(h: number): number {
+  return h >= 16 && h < 21 ? PEAK : OFF_PEAK;
+}
+
+function dateRange(start: Date, end: Date): string[] {
+  const dates: string[] = [];
+  const cur = new Date(start);
+  while (cur <= end) {
+    dates.push(cur.toISOString().split('T')[0]);
+    cur.setDate(cur.getDate() + 1);
+  }
+  return dates;
+}
+
+export async function handleNemAnalysis(request: Request, env: Env): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const startStr = searchParams.get('start');
+  const endStr = searchParams.get('end');
+  if (!startStr || !endStr) {
+    return new Response('missing start or end', { status: 400 });
+  }
+  const start = new Date(startStr);
+  const end = new Date(endStr);
+  const dates = dateRange(start, end);
+  const hours: HourRecord[] = [];
+  for (const date of dates) {
+    const usageRows = await queryDB<{hour:string, usage:number}>(env.DB,
+      'SELECT hour, usage FROM pge_usage WHERE date=?', [date]);
+    const pvRows = await queryDB<{hour:string, ac_wh:number}>(env.DB,
+      'SELECT hour, ac_wh FROM pvwatts_hourly WHERE date=?', [date]);
+    const pvMap: Record<string, number> = {};
+    for (const r of pvRows) pvMap[r.hour] = r.ac_wh;
+    for (const u of usageRows) {
+      hours.push({ date, hour: u.hour, usage: u.usage, pv: pvMap[u.hour] || 0 });
+    }
+  }
+  let costNEM2 = 0;
+  let costNEM3 = 0;
+  for (const h of hours) {
+    const rate = rateForHour(parseInt(h.hour));
+    const net = h.usage - h.pv;
+    if (net >= 0) {
+      costNEM2 += net * rate;
+      costNEM3 += net * rate;
+    } else {
+      costNEM2 += net * rate; // negative credit
+      costNEM3 += net * rate * 0.75;
+    }
+  }
+  const diff = costNEM3 - costNEM2;
+  return new Response(JSON.stringify({ costNEM2, costNEM3, diff, hours }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/solar-analyzer-worker/src/services/pvwattsBackfill.ts
+++ b/solar-analyzer-worker/src/services/pvwattsBackfill.ts
@@ -42,8 +42,13 @@ export async function handleBackfillPvwatts(request: Request, env: Env): Promise
     const year = date.slice(0,4);
     const yearArray = yearData[year];
     const idx = Math.floor((new Date(date).valueOf() - new Date(`${year}-01-01`).valueOf()) / 86400000);
-    const dayAc = yearArray.slice(idx*24, idx*24+24).reduce((a,b)=>a+(b||0),0);
+    const hours = yearArray.slice(idx*24, idx*24+24);
+    const dayAc = hours.reduce((a,b)=>a+(b||0),0);
     await execute(env.DB, 'INSERT INTO pvwatts (date, ac_wh) VALUES (?, ?)', [date, dayAc]);
+    for (let h=0; h<24; h++) {
+      const hour = h.toString().padStart(2,'0');
+      await execute(env.DB, 'INSERT INTO pvwatts_hourly (date, hour, ac_wh) VALUES (?, ?, ?)', [date, hour, hours[h] || 0]);
+    }
     inserted++;
   }
 

--- a/solar-analyzer-worker/test/index.spec.ts
+++ b/solar-analyzer-worker/test/index.spec.ts
@@ -28,6 +28,12 @@ CREATE TABLE IF NOT EXISTS pvwatts (
   dni REAL,
   dhi REAL
 );
+CREATE TABLE IF NOT EXISTS pvwatts_hourly (
+  date TEXT,
+  hour TEXT,
+  ac_wh REAL,
+  PRIMARY KEY(date, hour)
+);
 CREATE TABLE IF NOT EXISTS sunrise_sunset (
   date TEXT PRIMARY KEY,
   sunrise TEXT,
@@ -49,5 +55,19 @@ CREATE TABLE IF NOT EXISTS sunrise_sunset (
     expect(response.status).toBe(200);
     const data = await env.DB.prepare('SELECT count(*) as c FROM pge_usage').first<any>();
     expect(data.c).toBe(1);
+  });
+
+  it('calculates nem diff', async () => {
+    await env.DB.prepare('INSERT INTO pge_usage (date, hour, usage, units) VALUES ("2023-01-01", "00", 1, "kWh")').run();
+    await env.DB.prepare('INSERT INTO pvwatts_hourly (date, hour, ac_wh) VALUES ("2023-01-01", "00", 0.5)').run();
+    const request = new Request('http://example.com/analysis/nem2vnem3?start=2023-01-01&end=2023-01-01');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.costNEM2).toBeCloseTo(0.5 * 0.25);
+    expect(data.costNEM3).toBeCloseTo(0.5 * 0.25);
+    expect(data.diff).toBeCloseTo(0);
   });
 });


### PR DESCRIPTION
## Summary
- add hourly pvwatts table
- backfill service now writes hourly data
- expose /analysis/nem2vnem3 endpoint
- add simple ClickUp service
- create UI with charts and PDF download
- add tests for analysis

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685a10609e40832eab7e86a198640665